### PR TITLE
feat: add types generator script, generate types

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "generate-types": "dtsgen --url http://localhost:7777/api-docs-json -o ./src/types/generated.d.ts"
   },
   "dependencies": {
     "@emotion/cache": "^11.7.1",
@@ -26,6 +27,7 @@
     "@types/react-dom": "18.0.4",
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.23.0",
+    "dtsgenerator": "^3.15.1",
     "eslint": "8.15.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/src/types/generated.d.ts
+++ b/src/types/generated.d.ts
@@ -1,0 +1,4922 @@
+declare namespace Components {
+    namespace Schemas {
+        export interface AgencyBasicInfoDto {
+            id: string;
+            name: string;
+            slug: string;
+        }
+        export interface AgencyDto {
+            id: string;
+            name: string;
+            slug: string;
+            city?: string;
+            postalCode?: string;
+            street?: string;
+            transfermarktUrl?: string;
+            email?: string;
+            website?: string;
+            twitter?: string;
+            facebook?: string;
+            instagram?: string;
+            country: CountryDto;
+        }
+        export interface ApiPaginatedResponseDto {
+            success: boolean;
+            message: string;
+        }
+        export interface ApiResponseDto {
+            success: boolean;
+            message: string;
+        }
+        export interface ChangeRoleDto {
+            role: "ADMIN" | "PLAYMAKER_SCOUT" | "SCOUT";
+        }
+        export interface ClubBasicDataDto {
+            id: string;
+            name: string;
+            slug: string;
+        }
+        export interface ClubDto {
+            id: string;
+            name: string;
+            slug: string;
+            lnpId?: string;
+            city?: string;
+            postalCode?: string;
+            street?: string;
+            website?: string;
+            twitter?: string;
+            facebook?: string;
+            instagram?: string;
+            country: CountryDto;
+            region: RegionWithoutCountryDto;
+        }
+        export interface CompetitionAgeCategoryDto {
+            id: string;
+            name: string;
+        }
+        export interface CompetitionBasicDataDto {
+            id: string;
+            name: string;
+            level: number;
+            country: CountryDto;
+        }
+        export interface CompetitionDto {
+            id: string;
+            name: string;
+            level: number;
+            gender: "MALE" | "FEMALE";
+            country: CountryDto;
+            ageCategory: CompetitionAgeCategoryDto;
+            type: CompetitionTypeDto;
+            juniorLevel?: CompetitionJuniorLevelDto;
+        }
+        export interface CompetitionGroupBasicDataDto {
+            id: string;
+            name: string;
+            competition: CompetitionBasicDataDto;
+        }
+        export interface CompetitionGroupDto {
+            id: string;
+            name: string;
+            competition: CompetitionBasicDataDto;
+            regions: RegionWithoutCountryDto[];
+        }
+        export interface CompetitionJuniorLevelDto {
+            id: string;
+            name: string;
+            level: number;
+        }
+        export interface CompetitionParticipationDto {
+            season: SeasonDto;
+            team: TeamWithoutCompetitionsAndClubDto;
+            competition: CompetitionDto;
+            group: CompetitionGroupBasicDataDto;
+        }
+        export interface CompetitionParticipationWithoutTeamDto {
+            season?: SeasonDto;
+            competition?: CompetitionDto;
+            group?: CompetitionGroupBasicDataDto;
+        }
+        export interface CompetitionTypeDto {
+            id: string;
+            name: string;
+        }
+        export interface Count {
+            createdReports: number;
+            createdNotes: number;
+            createdInsiderNotes: number;
+        }
+        export interface CountryDto {
+            id: string;
+            name: string;
+            code: string;
+            isEuMember: boolean;
+        }
+        export interface CreateAgencyDto {
+            name: string;
+            countryId: string;
+            city?: string;
+            postalCode?: string;
+            street?: string;
+            transfermarktUrl?: string;
+            email?: string;
+            website?: string;
+            twitter?: string;
+            facebook?: string;
+            instagram?: string;
+        }
+        export interface CreateClubDto {
+            name: string;
+            regionId: string;
+            countryId: string;
+            lnpId?: string;
+            city?: string;
+            postalCode?: string;
+            street?: string;
+            website?: string;
+            twitter?: string;
+            facebook?: string;
+            instagram?: string;
+            isPublic?: boolean;
+        }
+        export interface CreateCompetitionAgeCategoryDto {
+            name: string;
+        }
+        export interface CreateCompetitionDto {
+            name: string;
+            level: number;
+            gender?: "MALE" | "FEMALE";
+            countryId: string;
+            ageCategoryId: string;
+            typeId: string;
+            juniorLevelId?: string;
+        }
+        export interface CreateCompetitionGroupDto {
+            name: string;
+            competitionId: string;
+            regionIds: string[];
+        }
+        export interface CreateCompetitionJuniorLevelDto {
+            name: string;
+            level: number;
+        }
+        export interface CreateCompetitionParticipationDto {
+            teamId: string;
+            competitionId: string;
+            seasonId: string;
+            groupId?: string;
+        }
+        export interface CreateCompetitionTypeDto {
+            name: string;
+        }
+        export interface CreateCountryDto {
+            name: string;
+            code: string;
+            isEuMember?: boolean;
+        }
+        export interface CreateInsiderNoteDto {
+            informant?: string;
+            description?: string;
+            playerId: string;
+            teamId?: string;
+            competitionId?: string;
+            competitionGroupId?: string;
+        }
+        export interface CreateMatchDto {
+            date: string;
+            homeGoals?: number;
+            awayGoals?: number;
+            videoUrl?: string;
+            homeTeamId: string;
+            awayTeamId: string;
+            competitionId: string;
+            groupId?: string;
+            seasonId: string;
+        }
+        export interface CreateNoteDto {
+            shirtNo?: number;
+            description?: string;
+            maxRatingScore?: number;
+            rating?: number;
+            playerId?: string;
+            matchId?: string;
+            positionPlayedId?: string;
+            teamId?: string;
+            competitionId?: string;
+            competitionGroupId?: string;
+        }
+        export interface CreateOrderDto {
+            playerId?: string;
+            matchId?: string;
+            description?: string;
+        }
+        export interface CreateOrganizationDto {
+            name: string;
+            memberIds: string[];
+        }
+        export interface CreateOrganizationInsiderNoteAceDto {
+            organizationId: string;
+            insiderNoteId: string;
+            permissionLevel?: "READ" | "READ_AND_WRITE" | "FULL";
+        }
+        export interface CreateOrganizationNoteAceDto {
+            organizationId: string;
+            noteId: string;
+            permissionLevel?: "READ" | "READ_AND_WRITE" | "FULL";
+        }
+        export interface CreateOrganizationPlayerAceDto {
+            organizationId: string;
+            playerId: string;
+            permissionLevel?: "READ" | "READ_AND_WRITE" | "FULL";
+        }
+        export interface CreateOrganizationReportAceDto {
+            organizationId: string;
+            reportId: string;
+            permissionLevel?: "READ" | "READ_AND_WRITE" | "FULL";
+        }
+        export interface CreateOrganizationSubscriptionDto {
+            organizationId: string;
+            startDate: string;
+            endDate: string;
+            competitionIds: string[];
+            competitionGroupIds: string[];
+        }
+        export interface CreatePlayerDto {
+            firstName: string;
+            lastName: string;
+            countryId: string;
+            primaryPositionId: string;
+            secondaryPositionIds?: string[];
+            teamId: string;
+            yearOfBirth: number;
+            height?: number;
+            weight?: number;
+            footed: "LEFT" | "RIGHT" | "BOTH";
+            lnpId?: string;
+            lnpUrl?: string;
+            minut90id?: string;
+            minut90url?: string;
+            transfermarktId?: string;
+            transfermarktUrl?: string;
+        }
+        export interface CreatePlayerPositionDto {
+            name: string;
+            code: string;
+        }
+        export interface CreatePlayerStatsDto {
+            playerId: string;
+            matchId: string;
+            minutesPlayed?: number;
+            goals?: number;
+            assists?: number;
+            yellowCards?: number;
+            redCards?: number;
+            teamId?: string;
+        }
+        export interface CreateRegionDto {
+            name: string;
+            countryId: string;
+        }
+        export interface CreateReportBackgroundImageDto {
+            name: string;
+            url: string;
+            isPublic: boolean;
+        }
+        export interface CreateReportDto {
+            shirtNo?: number;
+            minutesPlayed?: number;
+            goals?: number;
+            assists?: number;
+            yellowCards?: number;
+            redCards?: number;
+            videoUrl?: string;
+            videoDescription?: string;
+            finalRating?: number;
+            summary?: string;
+            templateId: string;
+            playerId: string;
+            positionPlayedId?: string;
+            teamId?: string;
+            competitionId?: string;
+            competitionGroupId?: string;
+            matchId?: string;
+            skillAssessments?: CreateReportSkillAssessmentDto[];
+        }
+        export interface CreateReportSkillAssessmentCategoryDto {
+            name: string;
+            isPublic?: boolean;
+        }
+        export interface CreateReportSkillAssessmentDto {
+            rating?: number;
+            description?: string;
+            templateId: string;
+        }
+        export interface CreateReportSkillAssessmentTemplateDto {
+            name: string;
+            shortName: string;
+            hasScore: boolean;
+            categoryId: string;
+        }
+        export interface CreateReportTemplateDto {
+            name: string;
+            maxRatingScore: number;
+            isPublic?: boolean;
+            skillAssessmentTemplateIds: string[];
+        }
+        export interface CreateSeasonDto {
+            name: string;
+            startDate: string;
+            endDate: string;
+        }
+        export interface CreateTeamAffiliationDto {
+            playerId: string;
+            teamId: string;
+            startDate: string;
+            endDate?: string;
+        }
+        export interface CreateTeamDto {
+            name: string;
+            clubId: string;
+            competitionId: string;
+            groupId?: string;
+            minut90url?: string;
+            transfermarktUrl?: string;
+            lnpId?: string;
+            isPublic?: boolean;
+        }
+        export interface CreateUserFootballRoleDto {
+            name: string;
+        }
+        export interface CreateUserInsiderNoteAceDto {
+            userId: string;
+            insiderNoteId: string;
+            permissionLevel?: "READ" | "READ_AND_WRITE" | "FULL";
+        }
+        export interface CreateUserNoteAceDto {
+            userId: string;
+            noteId: string;
+            permissionLevel?: "READ" | "READ_AND_WRITE" | "FULL";
+        }
+        export interface CreateUserPlayerAceDto {
+            userId: string;
+            playerId: string;
+            permissionLevel?: "READ" | "READ_AND_WRITE" | "FULL";
+        }
+        export interface CreateUserReportAceDto {
+            userId: string;
+            reportId: string;
+            permissionLevel?: "READ" | "READ_AND_WRITE" | "FULL";
+        }
+        export interface CreateUserSubscriptionDto {
+            userId: string;
+            startDate: string;
+            endDate: string;
+            competitionIds: string[];
+            competitionGroupIds: string[];
+        }
+        export interface FollowAgencyDto {
+            agency: AgencyBasicInfoDto;
+            follower: UserBasicDataDto;
+        }
+        export interface FollowPlayerDto {
+            player: PlayerBasicDataWithoutTeamsDto;
+            follower: UserBasicDataDto;
+        }
+        export interface FollowScoutDto {
+            scout: UserBasicDataDto;
+            follower: UserBasicDataDto;
+        }
+        export interface FollowTeamDto {
+            team: TeamBasicDataDto;
+            follower: UserBasicDataDto;
+        }
+        export interface ForgotPasswordDto {
+            email: string;
+        }
+        export interface InsiderNoteBasicDataDto {
+            id: string;
+            docNumber: number;
+            player: PlayerBasicDataWithoutTeamsDto;
+            author: UserBasicDataDto;
+        }
+        export interface InsiderNoteDto {
+            id: string;
+            docNumber: number;
+            informant?: string;
+            description?: string;
+            player: PlayerBasicDataWithoutTeamsDto;
+            author: UserBasicDataDto;
+            createdAt: string; // date-time
+            likes: LikeInsiderNoteBasicDataDto[];
+        }
+        export interface InsiderNotePaginatedDataDto {
+            player?: PlayerSuperBasicDataDto;
+            id: string;
+            docNumber: number;
+            informant?: string;
+            description?: string;
+            author: UserBasicDataDto;
+            createdAt: string; // date-time
+            likes: LikeInsiderNoteBasicDataDto[];
+        }
+        export interface InsiderNoteSuperBasicDataDto {
+            id: string;
+            docNumber: number;
+            createdAt: string; // date-time
+        }
+        export interface LikeInsiderNoteBasicDataDto {
+            userId: string;
+            insiderNoteId: string;
+        }
+        export interface LikeInsiderNoteDto {
+            insiderNote: InsiderNoteSuperBasicDataDto;
+            user: UserBasicDataDto;
+        }
+        export interface LikeNoteBasicDataDto {
+            userId: string;
+            noteId: string;
+        }
+        export interface LikeNoteDto {
+            note: NoteSuperBasicDataDto;
+            user: UserBasicDataDto;
+        }
+        export interface LikePlayerBasicDataDto {
+            userId: string;
+            playerId: string;
+        }
+        export interface LikePlayerDto {
+            player: PlayerSuperBasicDataDto;
+            user: UserBasicDataDto;
+        }
+        export interface LikeReportBasicDataDto {
+            userId: string;
+            reportId: string;
+        }
+        export interface LikeReportDto {
+            report: ReportSuperBasicDataDto;
+            user: UserBasicDataDto;
+        }
+        export interface LikeTeamBasicDataDto {
+            userId: string;
+            teamId: string;
+        }
+        export interface LikeTeamDto {
+            team: TeamBasicDataDto;
+            user: UserBasicDataDto;
+        }
+        export interface LoginDto {
+            email: string;
+            password: string;
+        }
+        export interface MatchAttendanceDto {
+            isActive: boolean;
+            user: UserBasicDataDto;
+            match: MatchBasicDataDto;
+        }
+        export interface MatchBasicDataDto {
+            id: string;
+            date: string; // date-time
+            homeTeam: TeamBasicDataDto;
+            awayTeam: TeamBasicDataDto;
+            competition: CompetitionBasicDataDto;
+        }
+        export interface MatchDto {
+            id: string;
+            date: string; // date-time
+            homeGoals?: number;
+            awayGoals?: number;
+            videoUrl?: string;
+            homeTeam: TeamBasicDataDto;
+            awayTeam: TeamBasicDataDto;
+            competition: CompetitionBasicDataDto;
+            group?: CompetitionGroupBasicDataDto;
+            season: SeasonBasicDataDto;
+            _count: Count;
+        }
+        export interface NoteBasicDataDto {
+            id: string;
+            player?: PlayerBasicDataWithoutTeamsDto;
+            description?: string;
+            rating?: number;
+            createdAt: string; // date-time
+            shirtNo?: number;
+            docNumber: number;
+        }
+        export interface NoteDto {
+            id: string;
+            docNumber: number;
+            shirtNo?: number;
+            description?: string;
+            maxRatingScore?: number;
+            rating?: number;
+            percentageRating?: number;
+            createdAt: string; // date-time
+            player?: PlayerBasicDataWithoutTeamsDto;
+            match?: MatchBasicDataDto;
+            author: UserBasicDataDto;
+            likes: LikeNoteBasicDataDto[];
+        }
+        export interface NotePaginatedDataDto {
+            player?: PlayerSuperBasicDataDto;
+            id: string;
+            docNumber: number;
+            shirtNo?: number;
+            description?: string;
+            maxRatingScore?: number;
+            rating?: number;
+            percentageRating?: number;
+            createdAt: string; // date-time
+            match?: MatchBasicDataDto;
+            author: UserBasicDataDto;
+            likes: LikeNoteBasicDataDto[];
+        }
+        export interface NoteSuperBasicDataDto {
+            id: string;
+            docNumber: number;
+            createdAt: string; // date-time
+        }
+        export interface OrderBasicDataDto {
+            player?: PlayerSuperBasicInfoDto;
+            id: string;
+            docNumber: number;
+            match?: MatchBasicDataDto;
+        }
+        export interface OrderDto {
+            id: string;
+            docNumber: number;
+            status: "OPEN" | "ACCEPTED" | "CLOSED";
+            description?: string;
+            acceptDate?: string; // date-time
+            closeDate?: string; // date-time
+            createdAt: string; // date-time
+            author: UserBasicDataDto;
+            scout?: UserBasicDataDto;
+            player?: PlayerBasicDataWithoutTeamsDto;
+            match?: MatchBasicDataDto;
+        }
+        export interface OrganizationBasicDataDto {
+            id: string;
+            name: string;
+        }
+        export interface OrganizationDto {
+            id: string;
+            name: string;
+            members: UserBasicDataDto[];
+            createdAt: string; // date-time
+        }
+        export interface OrganizationInsiderNoteAceDto {
+            id: string;
+            organization: OrganizationBasicDataDto;
+            insiderNote: InsiderNoteSuperBasicDataDto;
+            permissionLevel: "READ" | "READ_AND_WRITE" | "FULL";
+            createdAt: string; // date-time
+        }
+        export interface OrganizationNoteAceDto {
+            id: string;
+            organization: OrganizationBasicDataDto;
+            note: NoteSuperBasicDataDto;
+            permissionLevel: "READ" | "READ_AND_WRITE" | "FULL";
+            createdAt: string; // date-time
+        }
+        export interface OrganizationPlayerAceDto {
+            id: string;
+            organization: OrganizationBasicDataDto;
+            player: PlayerSuperBasicDataDto;
+            permissionLevel: "READ" | "READ_AND_WRITE" | "FULL";
+            createdAt: string; // date-time
+        }
+        export interface OrganizationReportAceDto {
+            id: string;
+            organization: OrganizationBasicDataDto;
+            report: ReportSuperBasicDataDto;
+            permissionLevel: "READ" | "READ_AND_WRITE" | "FULL";
+            createdAt: string; // date-time
+        }
+        export interface OrganizationSubscriptionDto {
+            id: string;
+            startDate: string; // date-time
+            endDate: string; // date-time
+            organization: OrganizationBasicDataDto;
+            competitions: CompetitionBasicDataDto;
+            competitionGroups: CompetitionGroupBasicDataDto;
+        }
+        export interface PasswordResetDto {
+            password: string; // [object Object]
+            passwordConfirm: string;
+        }
+        export interface PlayerBasicDataDto {
+            footed: "LEFT" | "RIGHT" | "BOTH";
+            id: string;
+            firstName: string;
+            lastName: string;
+            slug: string;
+            country: CountryDto;
+            yearOfBirth: number;
+            primaryPosition: PlayerPositionDto;
+            teams: TeamAffiliationWithoutPlayerDto[];
+        }
+        export interface PlayerBasicDataWithoutTeamsDto {
+            footed: "LEFT" | "RIGHT" | "BOTH";
+            id: string;
+            firstName: string;
+            lastName: string;
+            slug: string;
+            country: CountryDto;
+            yearOfBirth: number;
+            primaryPosition: PlayerPositionDto;
+        }
+        export interface PlayerDto {
+            footed: "LEFT" | "RIGHT" | "BOTH";
+            id: string;
+            firstName: string;
+            lastName: string;
+            slug: string;
+            yearOfBirth: number;
+            height?: number;
+            weight?: number;
+            lnpId?: string;
+            lnpUrl?: string;
+            minut90id?: string;
+            minut90url?: string;
+            transfermarktId?: string;
+            transfermarktUrl?: string;
+            country: CountryDto;
+            primaryPosition: PlayerPositionDto;
+            secondaryPositions: PlayerPositionDto[];
+            teams: TeamAffiliationWithoutPlayerDto[];
+            likes: LikePlayerBasicDataDto[];
+            _count: Count;
+        }
+        export interface PlayerPositionDto {
+            id: string;
+            name: string;
+            code: string;
+        }
+        export interface PlayerStatsDto {
+            id: string;
+            player: PlayerBasicDataDto;
+            match: MatchBasicDataDto;
+            minutesPlayed: number;
+            goals: number;
+            assists: number;
+            yellowCards: number;
+            redCards: number;
+        }
+        export interface PlayerSuperBasicDataDto {
+            id: string;
+            firstName: string;
+            lastName: string;
+            slug: string;
+        }
+        export interface PlayerSuperBasicInfoDto {
+            id: string;
+            firstName: string;
+            lastName: string;
+        }
+        export interface RegionDto {
+            id: string;
+            name: string;
+            country: CountryDto;
+        }
+        export interface RegionWithoutCountryDto {
+            id: string;
+            name: string;
+        }
+        export interface RegisterUserDto {
+            email: string;
+            firstName: string;
+            lastName: string;
+            clubId?: string;
+            footballRoleId?: string;
+            phone?: string;
+            city?: string;
+            password: string; // [object Object]
+            passwordConfirm: string;
+            activeRadius?: number;
+            regionId: string;
+        }
+        export interface ReportBackgroundImageDto {
+            id: string;
+            name: string;
+            url: string;
+        }
+        export interface ReportBasicDataDto {
+            id: string;
+            docNumber: number;
+            status: {
+                [key: string]: any;
+            };
+            player: PlayerSuperBasicDataDto;
+            author: UserBasicDataDto;
+        }
+        export interface ReportDto {
+            id: string;
+            docNumber: number;
+            minutesPlayed?: number;
+            goals?: number;
+            assists?: number;
+            yellowCards?: number;
+            redCards?: number;
+            videoUrl?: string;
+            videoDescription?: string;
+            finalRating?: number;
+            summary?: string;
+            avgRating?: number;
+            percentageRating?: number;
+            status: {
+                [key: string]: any;
+            };
+            createdAt: string; // date-time
+            template: ReportTemplateBasicDataDto;
+            player: PlayerSuperBasicDataDto;
+            match?: MatchBasicDataDto;
+            author: UserBasicDataDto;
+            skills: ReportSkillAssessmentBasicDataDto[];
+            likes: LikeReportBasicDataDto[];
+        }
+        export interface ReportPaginatedDataDto {
+            id: string;
+            docNumber: number;
+            player: PlayerSuperBasicDataDto;
+            finalRating?: number;
+            percentageRating?: number;
+            videoUrl?: string;
+            author: UserBasicDataDto;
+            createdAt: string; // date-time
+            status: {
+                [key: string]: any;
+            };
+            likes: LikeReportBasicDataDto[];
+        }
+        export interface ReportSkillAssessmentBasicDataDto {
+            id: string;
+            rating?: number;
+            description?: string;
+            template: ReportSkillAssessmentTemplateDto;
+        }
+        export interface ReportSkillAssessmentCategoryDto {
+            id: string;
+            name: string;
+        }
+        export interface ReportSkillAssessmentDto {
+            id: string;
+            rating?: number;
+            description?: string;
+            template: ReportSkillAssessmentTemplateDto;
+            report: ReportBasicDataDto;
+        }
+        export interface ReportSkillAssessmentTemplateDto {
+            id: string;
+            name: string;
+            shortName: string;
+            hasScore: boolean;
+            category: ReportSkillAssessmentCategoryDto;
+        }
+        export interface ReportSuperBasicDataDto {
+            id: string;
+            docNumber: number;
+            createdAt: string; // date-time
+        }
+        export interface ReportTemplateBasicDataDto {
+            id: string;
+            name: string;
+            maxRatingScore: number;
+        }
+        export interface ReportTemplateDto {
+            id: string;
+            name: string;
+            maxRatingScore: number;
+            skillAssessmentTemplates: ReportSkillAssessmentTemplateDto[];
+        }
+        export interface SeasonBasicDataDto {
+            id: string;
+            name: string;
+        }
+        export interface SeasonDto {
+            id: string;
+            name: string;
+            isActive: boolean;
+            startDate: string; // date-time
+            endDate: string; // date-time
+        }
+        export interface TeamAffiliationDto {
+            id: string;
+            player: PlayerBasicDataWithoutTeamsDto;
+            team: TeamBasicDataDto;
+            startDate: string; // date-time
+            endDate?: string; // date-time
+        }
+        export interface TeamAffiliationWithoutPlayerDto {
+            id: string;
+            team: TeamBasicDataDto;
+            startDate: string; // date-time
+            endDate?: string; // date-time
+        }
+        export interface TeamBasicDataDto {
+            id: string;
+            name: string;
+            slug: string;
+        }
+        export interface TeamDto {
+            id: string;
+            name: string;
+            slug: string;
+            competitions: CompetitionParticipationWithoutTeamDto[];
+            minut90url?: string;
+            transfermarktUrl?: string;
+            lnpId?: string;
+            club: ClubBasicDataDto;
+            likes: LikeTeamBasicDataDto[];
+        }
+        export interface TeamWithoutCompetitionsAndClubDto {
+            id: string;
+            name: string;
+            slug: string;
+            minut90url?: string;
+            transfermarktUrl?: string;
+            lnpId?: string;
+            likes: LikeTeamBasicDataDto[];
+        }
+        export interface ToggleIsActiveDto {
+            isActive: boolean;
+        }
+        export interface ToggleMembershipDto {
+            memberId: string;
+        }
+        export interface UpdateAgencyDto {
+            name?: string;
+            countryId?: string;
+            city?: string;
+            postalCode?: string;
+            street?: string;
+            transfermarktUrl?: string;
+            email?: string;
+            website?: string;
+            twitter?: string;
+            facebook?: string;
+            instagram?: string;
+        }
+        export interface UpdateClubDto {
+            name?: string;
+            regionId?: string;
+            countryId?: string;
+            lnpId?: string;
+            city?: string;
+            postalCode?: string;
+            street?: string;
+            website?: string;
+            twitter?: string;
+            facebook?: string;
+            instagram?: string;
+            isPublic?: boolean;
+        }
+        export interface UpdateCompetitionAgeCategoryDto {
+            name?: string;
+        }
+        export interface UpdateCompetitionDto {
+            name?: string;
+            level?: number;
+            gender?: "MALE" | "FEMALE";
+            countryId?: string;
+            ageCategoryId?: string;
+            typeId?: string;
+            juniorLevelId?: string;
+        }
+        export interface UpdateCompetitionGroupDto {
+            name?: string;
+            competitionId?: string;
+            regionIds?: string[];
+        }
+        export interface UpdateCompetitionJuniorLevelDto {
+            name?: string;
+            level?: number;
+        }
+        export interface UpdateCompetitionParticipationDto {
+            teamId?: string;
+            competitionId?: string;
+            seasonId?: string;
+            groupId?: string;
+        }
+        export interface UpdateCompetitionTypeDto {
+            name?: string;
+        }
+        export interface UpdateCountryDto {
+            name?: string;
+            code?: string;
+            isEuMember?: boolean;
+        }
+        export interface UpdateInsiderNoteDto {
+            informant?: string;
+            description?: string;
+            playerId?: string;
+            teamId?: string;
+            competitionId?: string;
+            competitionGroupId?: string;
+        }
+        export interface UpdateMatchDto {
+            date?: string;
+            homeGoals?: number;
+            awayGoals?: number;
+            videoUrl?: string;
+            homeTeamId?: string;
+            awayTeamId?: string;
+            competitionId?: string;
+            groupId?: string;
+            seasonId?: string;
+        }
+        export interface UpdateNoteDto {
+            shirtNo?: number;
+            description?: string;
+            maxRatingScore?: number;
+            rating?: number;
+            playerId?: string;
+            matchId?: string;
+            positionPlayedId?: string;
+            teamId?: string;
+            competitionId?: string;
+            competitionGroupId?: string;
+        }
+        export interface UpdateOrganizationDto {
+            name?: string;
+        }
+        export interface UpdateOrganizationInsiderNoteAceDto {
+            permissionLevel?: "READ" | "READ_AND_WRITE" | "FULL";
+        }
+        export interface UpdateOrganizationNoteAceDto {
+            permissionLevel?: "READ" | "READ_AND_WRITE" | "FULL";
+        }
+        export interface UpdateOrganizationPlayerAceDto {
+            permissionLevel?: "READ" | "READ_AND_WRITE" | "FULL";
+        }
+        export interface UpdateOrganizationReportAceDto {
+            permissionLevel?: "READ" | "READ_AND_WRITE" | "FULL";
+        }
+        export interface UpdateOrganizationSubscriptionDto {
+            startDate?: string;
+            endDate?: string;
+            competitionIds?: string[];
+            competitionGroupIds?: string[];
+        }
+        export interface UpdatePasswordDto {
+            oldPassword: string;
+            newPassword: string; // [object Object]
+            newPasswordConfirm: string;
+        }
+        export interface UpdatePlayerDto {
+            firstName?: string;
+            lastName?: string;
+            countryId?: string;
+            primaryPositionId?: string;
+            secondaryPositionIds?: string[];
+            yearOfBirth?: number;
+            height?: number;
+            weight?: number;
+            footed?: "LEFT" | "RIGHT" | "BOTH";
+            lnpId?: string;
+            lnpUrl?: string;
+            minut90id?: string;
+            minut90url?: string;
+            transfermarktId?: string;
+            transfermarktUrl?: string;
+        }
+        export interface UpdatePlayerPositionDto {
+            name?: string;
+            code?: string;
+        }
+        export interface UpdatePlayerStatsDto {
+            playerId?: string;
+            matchId?: string;
+            minutesPlayed?: number;
+            goals?: number;
+            assists?: number;
+            yellowCards?: number;
+            redCards?: number;
+            teamId?: string;
+        }
+        export interface UpdateRegionDto {
+            name?: string;
+            countryId?: string;
+        }
+        export interface UpdateReportBackgroundImageDto {
+            name?: string;
+            url?: string;
+            isPublic?: boolean;
+        }
+        export interface UpdateReportDto {
+            shirtNo?: number;
+            minutesPlayed?: number;
+            goals?: number;
+            assists?: number;
+            yellowCards?: number;
+            redCards?: number;
+            videoUrl?: string;
+            videoDescription?: string;
+            finalRating?: number;
+            summary?: string;
+            playerId?: string;
+            positionPlayedId?: string;
+            teamId?: string;
+            competitionId?: string;
+            competitionGroupId?: string;
+            matchId?: string;
+            skillAssessments?: CreateReportSkillAssessmentDto[];
+        }
+        export interface UpdateReportSkillAssessmentCategoryDto {
+            name?: string;
+            isPublic?: boolean;
+        }
+        export interface UpdateReportSkillAssessmentTemplateDto {
+            name?: string;
+            shortName?: string;
+            hasScore?: boolean;
+            categoryId?: string;
+        }
+        export interface UpdateReportTemplateDto {
+            name?: string;
+            maxRatingScore?: number;
+            isPublic?: boolean;
+            skillAssessmentTemplateIds?: string[];
+        }
+        export interface UpdateSeasonDto {
+            name?: string;
+            startDate?: string;
+            endDate?: string;
+        }
+        export interface UpdateTeamAffiliationDto {
+            startDate?: string;
+            endDate?: string;
+        }
+        export interface UpdateTeamDto {
+            name?: string;
+            clubId?: string;
+            minut90url?: string;
+            transfermarktUrl?: string;
+            lnpId?: string;
+        }
+        export interface UpdateUserDto {
+            firstName?: string;
+            lastName?: string;
+            clubId?: string;
+            footballRoleId?: string;
+            phone?: string;
+            city?: string;
+            activeRadius?: number;
+            regionId?: string;
+        }
+        export interface UpdateUserFootballRoleDto {
+            name?: string;
+        }
+        export interface UpdateUserInsiderNoteAceDto {
+            permissionLevel?: "READ" | "READ_AND_WRITE" | "FULL";
+        }
+        export interface UpdateUserNoteAceDto {
+            permissionLevel?: "READ" | "READ_AND_WRITE" | "FULL";
+        }
+        export interface UpdateUserPlayerAceDto {
+            permissionLevel?: "READ" | "READ_AND_WRITE" | "FULL";
+        }
+        export interface UpdateUserReportAceDto {
+            permissionLevel?: "READ" | "READ_AND_WRITE" | "FULL";
+        }
+        export interface UpdateUserSubscriptionDto {
+            startDate?: string;
+            endDate?: string;
+            competitionIds?: string[];
+            competitionGroupIds?: string[];
+        }
+        export interface UserBasicDataDto {
+            id: string;
+            firstName: string;
+            lastName: string;
+        }
+        export interface UserDto {
+            role: "SCOUT" | "PLAYMAKER_SCOUT" | "ADMIN";
+            status: "PENDING" | "ACTIVE" | "BLOCKED";
+            id: string;
+            email: string;
+            firstName: string;
+            lastName: string;
+            phone?: string;
+            city?: string;
+            activeRadius: number;
+            region: RegionDto;
+            club?: ClubBasicDataDto;
+            footballRole?: UserFootballRoleDto;
+            _count: Count;
+        }
+        export interface UserFootballRoleDto {
+            id: string;
+            name: string;
+        }
+        export interface UserInsiderNoteAceDto {
+            id: string;
+            user: UserBasicDataDto;
+            insiderNote: InsiderNoteSuperBasicDataDto;
+            permissionLevel: "READ" | "READ_AND_WRITE" | "FULL";
+            createdAt: string; // date-time
+        }
+        export interface UserNoteAceDto {
+            id: string;
+            user: UserBasicDataDto;
+            note: NoteSuperBasicDataDto;
+            permissionLevel: "READ" | "READ_AND_WRITE" | "FULL";
+            createdAt: string; // date-time
+        }
+        export interface UserPlayerAceDto {
+            id: string;
+            user: UserBasicDataDto;
+            player: PlayerSuperBasicDataDto;
+            permissionLevel: "READ" | "READ_AND_WRITE" | "FULL";
+            createdAt: string; // date-time
+        }
+        export interface UserReportAceDto {
+            id: string;
+            user: UserBasicDataDto;
+            report: ReportSuperBasicDataDto;
+            permissionLevel: "READ" | "READ_AND_WRITE" | "FULL";
+            createdAt: string; // date-time
+        }
+        export interface UserSubscriptionDto {
+            id: string;
+            startDate: string; // date-time
+            endDate: string; // date-time
+            user: UserBasicDataDto;
+            competitions: CompetitionBasicDataDto;
+            competitionGroups: CompetitionGroupBasicDataDto;
+        }
+    }
+}
+declare namespace Paths {
+    namespace AgenciesControllerCreate {
+        export type RequestBody = Components.Schemas.CreateAgencyDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.AgencyDto;
+            }
+        }
+    }
+    namespace AgenciesControllerFindAll {
+        namespace Parameters {
+            export type CountryId = string;
+            export type Limit = number;
+            export type Name = string;
+            export type Page = number;
+            export type SortBy = "id" | "name" | "country";
+            export type SortingOrder = "asc" | "desc";
+        }
+        export interface QueryParameters {
+            name?: Parameters.Name;
+            countryId?: Parameters.CountryId;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.AgencyDto;
+            }
+        }
+    }
+    namespace AgenciesControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.AgencyDto;
+            }
+        }
+    }
+    namespace AgenciesControllerGetList {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.AgencyBasicInfoDto;
+            }
+        }
+    }
+    namespace AgenciesControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.AgencyDto;
+            }
+        }
+    }
+    namespace AgenciesControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateAgencyDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.AgencyDto;
+            }
+        }
+    }
+    namespace AppControllerGetHello {
+        namespace Responses {
+            export type $200 = string;
+        }
+    }
+    namespace AuthControllerForgotPassword {
+        export type RequestBody = Components.Schemas.ForgotPasswordDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserDto;
+            }
+        }
+    }
+    namespace AuthControllerGetAccount {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserDto;
+            }
+        }
+    }
+    namespace AuthControllerLogin {
+        export type RequestBody = Components.Schemas.LoginDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserDto;
+            }
+        }
+    }
+    namespace AuthControllerRegister {
+        export type RequestBody = Components.Schemas.RegisterUserDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserDto;
+            }
+        }
+    }
+    namespace AuthControllerResetPassword {
+        namespace Parameters {
+            export type ResetPasswordToken = string;
+        }
+        export interface PathParameters {
+            resetPasswordToken: Parameters.ResetPasswordToken;
+        }
+        export type RequestBody = Components.Schemas.PasswordResetDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserDto;
+            }
+        }
+    }
+    namespace AuthControllerUpdateAccount {
+        export type RequestBody = Components.Schemas.UpdateUserDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserDto;
+            }
+        }
+    }
+    namespace AuthControllerUpdatePassword {
+        export type RequestBody = Components.Schemas.UpdatePasswordDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserDto;
+            }
+        }
+    }
+    namespace AuthControllerVerify {
+        namespace Parameters {
+            export type ConfirmationCode = string;
+        }
+        export interface PathParameters {
+            confirmationCode: Parameters.ConfirmationCode;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserDto;
+            }
+        }
+    }
+    namespace ClubsControllerCreate {
+        export type RequestBody = Components.Schemas.CreateClubDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ClubDto;
+            }
+        }
+    }
+    namespace ClubsControllerFindAll {
+        namespace Parameters {
+            export type CountryId = string;
+            export type Limit = number;
+            export type Name = string;
+            export type Page = number;
+            export type RegionId = string;
+            export type SortBy = "id" | "name" | "countryId" | "regionId";
+            export type SortingOrder = "asc" | "desc";
+        }
+        export interface QueryParameters {
+            name?: Parameters.Name;
+            regionId?: Parameters.RegionId;
+            countryId?: Parameters.CountryId;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.ClubDto[];
+                };
+            }
+        }
+    }
+    namespace ClubsControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ClubDto;
+            }
+        }
+    }
+    namespace ClubsControllerGetList {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ClubBasicDataDto;
+            }
+        }
+    }
+    namespace ClubsControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ClubDto;
+            }
+        }
+    }
+    namespace ClubsControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateClubDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ClubDto;
+            }
+        }
+    }
+    namespace CompetitionAgeCategoriesControllerCreate {
+        export type RequestBody = Components.Schemas.CreateCompetitionAgeCategoryDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionAgeCategoryDto;
+            }
+        }
+    }
+    namespace CompetitionAgeCategoriesControllerFindAll {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionAgeCategoryDto[];
+            }
+        }
+    }
+    namespace CompetitionAgeCategoriesControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionAgeCategoryDto;
+            }
+        }
+    }
+    namespace CompetitionAgeCategoriesControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionAgeCategoryDto;
+            }
+        }
+    }
+    namespace CompetitionAgeCategoriesControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateCompetitionAgeCategoryDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionAgeCategoryDto;
+            }
+        }
+    }
+    namespace CompetitionGroupsControllerCreate {
+        export type RequestBody = Components.Schemas.CreateCompetitionGroupDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionGroupDto;
+            }
+        }
+    }
+    namespace CompetitionGroupsControllerFindAll {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionGroupDto[];
+            }
+        }
+    }
+    namespace CompetitionGroupsControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionGroupDto;
+            }
+        }
+    }
+    namespace CompetitionGroupsControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionGroupDto;
+            }
+        }
+    }
+    namespace CompetitionGroupsControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateCompetitionGroupDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionGroupDto;
+            }
+        }
+    }
+    namespace CompetitionJuniorLevelsControllerCreate {
+        export type RequestBody = Components.Schemas.CreateCompetitionJuniorLevelDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionJuniorLevelDto;
+            }
+        }
+    }
+    namespace CompetitionJuniorLevelsControllerFindAll {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionJuniorLevelDto[];
+            }
+        }
+    }
+    namespace CompetitionJuniorLevelsControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionJuniorLevelDto;
+            }
+        }
+    }
+    namespace CompetitionJuniorLevelsControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionJuniorLevelDto;
+            }
+        }
+    }
+    namespace CompetitionJuniorLevelsControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateCompetitionJuniorLevelDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionJuniorLevelDto;
+            }
+        }
+    }
+    namespace CompetitionParticipationsControllerCopyFromSeasonToSeason {
+        namespace Parameters {
+            export type FromSeasonId = string;
+            export type ToSeasonId = string;
+        }
+        export interface PathParameters {
+            fromSeasonId: Parameters.FromSeasonId;
+            toSeasonId: Parameters.ToSeasonId;
+        }
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionParticipationDto;
+            }
+        }
+    }
+    namespace CompetitionParticipationsControllerCreate {
+        export type RequestBody = Components.Schemas.CreateCompetitionParticipationDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionParticipationDto;
+            }
+        }
+    }
+    namespace CompetitionParticipationsControllerFindAll {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionParticipationDto;
+            }
+        }
+    }
+    namespace CompetitionParticipationsControllerFindOne {
+        namespace Parameters {
+            export type CompetitionId = string;
+            export type SeasonId = string;
+            export type TeamId = string;
+        }
+        export interface PathParameters {
+            teamId: Parameters.TeamId;
+            competitionId: Parameters.CompetitionId;
+            seasonId: Parameters.SeasonId;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionParticipationDto;
+            }
+        }
+    }
+    namespace CompetitionParticipationsControllerRemove {
+        namespace Parameters {
+            export type CompetitionId = string;
+            export type SeasonId = string;
+            export type TeamId = string;
+        }
+        export interface PathParameters {
+            teamId: Parameters.TeamId;
+            competitionId: Parameters.CompetitionId;
+            seasonId: Parameters.SeasonId;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionParticipationDto;
+            }
+        }
+    }
+    namespace CompetitionParticipationsControllerUpdate {
+        namespace Parameters {
+            export type CompetitionId = string;
+            export type SeasonId = string;
+            export type TeamId = string;
+        }
+        export interface PathParameters {
+            teamId: Parameters.TeamId;
+            competitionId: Parameters.CompetitionId;
+            seasonId: Parameters.SeasonId;
+        }
+        export type RequestBody = Components.Schemas.UpdateCompetitionParticipationDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionParticipationDto;
+            }
+        }
+    }
+    namespace CompetitionTypesControllerCreate {
+        export type RequestBody = Components.Schemas.CreateCompetitionTypeDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionTypeDto;
+            }
+        }
+    }
+    namespace CompetitionTypesControllerFindAll {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionTypeDto[];
+            }
+        }
+    }
+    namespace CompetitionTypesControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionTypeDto;
+            }
+        }
+    }
+    namespace CompetitionTypesControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionTypeDto;
+            }
+        }
+    }
+    namespace CompetitionTypesControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateCompetitionTypeDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionTypeDto;
+            }
+        }
+    }
+    namespace CompetitionsControllerCreate {
+        export type RequestBody = Components.Schemas.CreateCompetitionDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionDto;
+            }
+        }
+    }
+    namespace CompetitionsControllerFindAll {
+        namespace Parameters {
+            export type AgeCategoryId = string;
+            export type CountryId = string;
+            export type Gender = "MALE" | "FEMALE";
+            export type JuniorLevelId = string;
+            export type Level = number;
+            export type Limit = number;
+            export type Name = string;
+            export type Page = number;
+            export type SortBy = "id" | "name" | "level" | "gender" | "country" | "ageCategory" | "type" | "juniorLevel";
+            export type SortingOrder = "asc" | "desc";
+            export type TypeId = string;
+        }
+        export interface QueryParameters {
+            name?: Parameters.Name;
+            level?: Parameters.Level;
+            gender?: Parameters.Gender;
+            countryId?: Parameters.CountryId;
+            ageCategoryId?: Parameters.AgeCategoryId;
+            typeId?: Parameters.TypeId;
+            juniorLevelId?: Parameters.JuniorLevelId;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.CompetitionDto[];
+                };
+            }
+        }
+    }
+    namespace CompetitionsControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionDto;
+            }
+        }
+    }
+    namespace CompetitionsControllerGetList {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionBasicDataDto;
+            }
+        }
+    }
+    namespace CompetitionsControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionDto;
+            }
+        }
+    }
+    namespace CompetitionsControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateCompetitionDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CompetitionDto;
+            }
+        }
+    }
+    namespace CountriesControllerCreate {
+        export type RequestBody = Components.Schemas.CreateCountryDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CountryDto;
+            }
+        }
+    }
+    namespace CountriesControllerFindAll {
+        namespace Parameters {
+            export type IsEuMember = boolean;
+            export type Limit = number;
+            export type Page = number;
+            export type SortBy = "id" | "name" | "code" | "isEuMember";
+            export type SortingOrder = "asc" | "desc";
+        }
+        export interface QueryParameters {
+            isEuMember?: Parameters.IsEuMember;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.CountryDto[];
+                };
+            }
+        }
+    }
+    namespace CountriesControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CountryDto;
+            }
+        }
+    }
+    namespace CountriesControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CountryDto;
+            }
+        }
+    }
+    namespace CountriesControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateCountryDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.CountryDto;
+            }
+        }
+    }
+    namespace FollowAgenciesControllerCreate {
+        namespace Parameters {
+            export type AgencyId = string;
+        }
+        export interface PathParameters {
+            agencyId: Parameters.AgencyId;
+        }
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.FollowAgencyDto;
+            }
+        }
+    }
+    namespace FollowAgenciesControllerRemove {
+        namespace Parameters {
+            export type AgencyId = string;
+        }
+        export interface PathParameters {
+            agencyId: Parameters.AgencyId;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.FollowAgencyDto;
+            }
+        }
+    }
+    namespace FollowPlayersControllerCreate {
+        namespace Parameters {
+            export type PlayerId = string;
+        }
+        export interface PathParameters {
+            playerId: Parameters.PlayerId;
+        }
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.FollowPlayerDto;
+            }
+        }
+    }
+    namespace FollowPlayersControllerRemove {
+        namespace Parameters {
+            export type PlayerId = string;
+        }
+        export interface PathParameters {
+            playerId: Parameters.PlayerId;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.FollowPlayerDto;
+            }
+        }
+    }
+    namespace FollowScoutsControllerCreate {
+        namespace Parameters {
+            export type ScoutId = string;
+        }
+        export interface PathParameters {
+            scoutId: Parameters.ScoutId;
+        }
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.FollowScoutDto;
+            }
+        }
+    }
+    namespace FollowScoutsControllerRemove {
+        namespace Parameters {
+            export type ScoutId = string;
+        }
+        export interface PathParameters {
+            scoutId: Parameters.ScoutId;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.FollowScoutDto;
+            }
+        }
+    }
+    namespace FollowTeamsControllerCreate {
+        namespace Parameters {
+            export type TeamId = string;
+        }
+        export interface PathParameters {
+            teamId: Parameters.TeamId;
+        }
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.FollowTeamDto;
+            }
+        }
+    }
+    namespace FollowTeamsControllerRemove {
+        namespace Parameters {
+            export type TeamId = string;
+        }
+        export interface PathParameters {
+            teamId: Parameters.TeamId;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.FollowTeamDto;
+            }
+        }
+    }
+    namespace InsiderNotesControllerCreate {
+        export type RequestBody = Components.Schemas.CreateInsiderNoteDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.InsiderNoteDto;
+            }
+        }
+    }
+    namespace InsiderNotesControllerFindAll {
+        namespace Parameters {
+            export type CompetitionGroupIds = string[];
+            export type CompetitionIds = string[];
+            export type IsLiked = boolean;
+            export type Limit = number;
+            export type Page = number;
+            export type PlayerIds = string[];
+            export type PositionIds = string[];
+            export type SortBy = "id" | "player" | "createdAt";
+            export type SortingOrder = "asc" | "desc";
+            export type TeamIds = string[];
+        }
+        export interface QueryParameters {
+            playerIds?: Parameters.PlayerIds;
+            positionIds?: Parameters.PositionIds;
+            teamIds?: Parameters.TeamIds;
+            competitionIds?: Parameters.CompetitionIds;
+            competitionGroupIds?: Parameters.CompetitionGroupIds;
+            isLiked?: Parameters.IsLiked;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.InsiderNotePaginatedDataDto[];
+                };
+            }
+        }
+    }
+    namespace InsiderNotesControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+            }
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.InsiderNoteDto;
+            }
+        }
+    }
+    namespace InsiderNotesControllerGetList {
+        namespace Responses {
+            export interface $200 {
+            }
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.InsiderNoteBasicDataDto;
+            }
+        }
+    }
+    namespace InsiderNotesControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.InsiderNoteDto;
+            }
+        }
+    }
+    namespace InsiderNotesControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateInsiderNoteDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.InsiderNoteDto;
+            }
+        }
+    }
+    namespace InsiderNotesLikesControllerCreate {
+        namespace Parameters {
+            export type InsiderNoteId = string;
+        }
+        export interface PathParameters {
+            insiderNoteId: Parameters.InsiderNoteId;
+        }
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.LikeInsiderNoteDto;
+            }
+        }
+    }
+    namespace InsiderNotesLikesControllerRemove {
+        namespace Parameters {
+            export type InsiderNoteId = string;
+        }
+        export interface PathParameters {
+            insiderNoteId: Parameters.InsiderNoteId;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.LikeInsiderNoteDto;
+            }
+        }
+    }
+    namespace LikeNotesControllerCreate {
+        namespace Parameters {
+            export type NoteId = string;
+        }
+        export interface PathParameters {
+            noteId: Parameters.NoteId;
+        }
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.LikeNoteDto;
+            }
+        }
+    }
+    namespace LikeNotesControllerRemove {
+        namespace Parameters {
+            export type NoteId = string;
+        }
+        export interface PathParameters {
+            noteId: Parameters.NoteId;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.LikeNoteDto;
+            }
+        }
+    }
+    namespace LikePlayersControllerCreate {
+        namespace Parameters {
+            export type PlayerId = string;
+        }
+        export interface PathParameters {
+            playerId: Parameters.PlayerId;
+        }
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.LikePlayerDto;
+            }
+        }
+    }
+    namespace LikePlayersControllerRemove {
+        namespace Parameters {
+            export type PlayerId = string;
+        }
+        export interface PathParameters {
+            playerId: Parameters.PlayerId;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.LikePlayerDto;
+            }
+        }
+    }
+    namespace LikeReportsControllerCreate {
+        namespace Parameters {
+            export type ReportId = string;
+        }
+        export interface PathParameters {
+            reportId: Parameters.ReportId;
+        }
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.LikeReportDto;
+            }
+        }
+    }
+    namespace LikeReportsControllerRemove {
+        namespace Parameters {
+            export type ReportId = string;
+        }
+        export interface PathParameters {
+            reportId: Parameters.ReportId;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.LikeReportDto;
+            }
+        }
+    }
+    namespace LikeTeamsControllerCreate {
+        namespace Parameters {
+            export type TeamId = string;
+        }
+        export interface PathParameters {
+            teamId: Parameters.TeamId;
+        }
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.LikeTeamDto;
+            }
+        }
+    }
+    namespace LikeTeamsControllerRemove {
+        namespace Parameters {
+            export type TeamId = string;
+        }
+        export interface PathParameters {
+            teamId: Parameters.TeamId;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.LikeTeamDto;
+            }
+        }
+    }
+    namespace MatchAttendancesControllerFindActiveByUserId {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.MatchAttendanceDto;
+            }
+        }
+    }
+    namespace MatchAttendancesControllerGoToMatch {
+        namespace Parameters {
+            export type MatchId = string;
+        }
+        export interface PathParameters {
+            matchId: Parameters.MatchId;
+        }
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.MatchAttendanceDto;
+            }
+        }
+    }
+    namespace MatchAttendancesControllerLeaveTheMatch {
+        namespace Parameters {
+            export type MatchId = string;
+        }
+        export interface PathParameters {
+            matchId: Parameters.MatchId;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.MatchAttendanceDto;
+            }
+        }
+    }
+    namespace MatchesControllerCreate {
+        export type RequestBody = Components.Schemas.CreateMatchDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.MatchDto;
+            }
+        }
+    }
+    namespace MatchesControllerFindAll {
+        namespace Parameters {
+            export type CompetitionIds = string[];
+            export type GroupIds = string[];
+            export type HasVideo = boolean;
+            export type Limit = number;
+            export type Page = number;
+            export type SeasonId = string;
+            export type SortBy = "id" | "date" | "homeTeam" | "awayTeam" | "competition" | "group" | "season" | "reportsCount" | "notesCount" | "videoUrl";
+            export type SortingOrder = "asc" | "desc";
+            export type TeamId = string;
+        }
+        export interface QueryParameters {
+            teamId?: Parameters.TeamId;
+            competitionIds?: Parameters.CompetitionIds;
+            groupIds?: Parameters.GroupIds;
+            seasonId?: Parameters.SeasonId;
+            hasVideo?: Parameters.HasVideo;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.MatchDto[];
+                };
+            }
+        }
+    }
+    namespace MatchesControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.MatchDto;
+            }
+        }
+    }
+    namespace MatchesControllerGetList {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.MatchBasicDataDto;
+            }
+        }
+    }
+    namespace MatchesControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.MatchDto;
+            }
+        }
+    }
+    namespace MatchesControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateMatchDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.MatchDto;
+            }
+        }
+    }
+    namespace NotesControllerCreate {
+        export type RequestBody = Components.Schemas.CreateNoteDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.NoteDto;
+            }
+        }
+    }
+    namespace NotesControllerFindAll {
+        namespace Parameters {
+            export type CompetitionGroupIds = string[];
+            export type CompetitionIds = string[];
+            export type IsLiked = boolean;
+            export type Limit = number;
+            export type MatchIds = string[];
+            export type Page = number;
+            export type PercentageRatingRangeEnd = number;
+            export type PercentageRatingRangeStart = number;
+            export type PlayerBornAfter = number;
+            export type PlayerBornBefore = number;
+            export type PlayerIds = string[];
+            export type PositionIds = string[];
+            export type SortBy = "id" | "player" | "positionPlayed" | "percentageRating" | "match" | "author" | "createdAt";
+            export type SortingOrder = "asc" | "desc";
+            export type TeamIds = string[];
+        }
+        export interface QueryParameters {
+            playerIds?: Parameters.PlayerIds;
+            positionIds?: Parameters.PositionIds;
+            teamIds?: Parameters.TeamIds;
+            matchIds?: Parameters.MatchIds;
+            competitionIds?: Parameters.CompetitionIds;
+            competitionGroupIds?: Parameters.CompetitionGroupIds;
+            percentageRatingRangeStart?: Parameters.PercentageRatingRangeStart;
+            percentageRatingRangeEnd?: Parameters.PercentageRatingRangeEnd;
+            playerBornAfter?: Parameters.PlayerBornAfter;
+            playerBornBefore?: Parameters.PlayerBornBefore;
+            isLiked?: Parameters.IsLiked;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.NotePaginatedDataDto[];
+                };
+            }
+        }
+    }
+    namespace NotesControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.NoteDto;
+            }
+        }
+    }
+    namespace NotesControllerGetList {
+        namespace Parameters {
+            export type MatchIds = string[];
+        }
+        export interface QueryParameters {
+            matchIds?: Parameters.MatchIds;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.NoteBasicDataDto;
+            }
+        }
+    }
+    namespace NotesControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.NoteDto;
+            }
+        }
+    }
+    namespace NotesControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateNoteDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.NoteDto;
+            }
+        }
+    }
+    namespace OrdersControllerAccept {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrderDto;
+            }
+        }
+    }
+    namespace OrdersControllerClose {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrderDto;
+            }
+        }
+    }
+    namespace OrdersControllerCreate {
+        export type RequestBody = Components.Schemas.CreateOrderDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrderDto;
+            }
+        }
+    }
+    namespace OrdersControllerFindAll {
+        namespace Parameters {
+            export type CreatedAfter = string;
+            export type CreatedBefore = string;
+            export type Limit = number;
+            export type MatchIds = string[];
+            export type Page = number;
+            export type PlayerIds = string[];
+            export type SortBy = "id" | "player" | "position" | "status" | "scout" | "description" | "createdAt";
+            export type SortingOrder = "asc" | "desc";
+            export type Status = "OPEN" | "ACCEPTED" | "CLOSED";
+            export type TeamIds = string[];
+            export type UserId = string;
+        }
+        export interface QueryParameters {
+            userId?: Parameters.UserId;
+            playerIds?: Parameters.PlayerIds;
+            teamIds?: Parameters.TeamIds;
+            matchIds?: Parameters.MatchIds;
+            status?: Parameters.Status;
+            createdAfter?: Parameters.CreatedAfter;
+            createdBefore?: Parameters.CreatedBefore;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.OrderDto[];
+                };
+            }
+        }
+    }
+    namespace OrdersControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrderDto;
+            }
+        }
+    }
+    namespace OrdersControllerGetList {
+        namespace Parameters {
+            export type CreatedAfter = string;
+            export type CreatedBefore = string;
+            export type MatchIds = string[];
+            export type PlayerIds = string[];
+            export type Status = "OPEN" | "ACCEPTED" | "CLOSED";
+            export type TeamIds = string[];
+            export type UserId = string;
+        }
+        export interface QueryParameters {
+            userId?: Parameters.UserId;
+            playerIds?: Parameters.PlayerIds;
+            teamIds?: Parameters.TeamIds;
+            matchIds?: Parameters.MatchIds;
+            status?: Parameters.Status;
+            createdAfter?: Parameters.CreatedAfter;
+            createdBefore?: Parameters.CreatedBefore;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrderBasicDataDto;
+            }
+        }
+    }
+    namespace OrdersControllerReject {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrderDto;
+            }
+        }
+    }
+    namespace OrdersControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrderDto;
+            }
+        }
+    }
+    namespace OrganizationInsiderNoteAclControllerCreate {
+        export type RequestBody = Components.Schemas.CreateOrganizationInsiderNoteAceDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationInsiderNoteAceDto;
+            }
+        }
+    }
+    namespace OrganizationInsiderNoteAclControllerFindAll {
+        namespace Parameters {
+            export type InsiderNoteId = string;
+            export type Limit = number;
+            export type OrganizationId = string;
+            export type Page = number;
+            export type SortBy = "id" | "organization" | "insiderNote" | "createdAt";
+            export type SortingOrder = "asc" | "desc";
+        }
+        export interface QueryParameters {
+            organizationId?: Parameters.OrganizationId;
+            insiderNoteId?: Parameters.InsiderNoteId;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.OrganizationInsiderNoteAceDto[];
+                };
+            }
+        }
+    }
+    namespace OrganizationInsiderNoteAclControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationInsiderNoteAceDto;
+            }
+        }
+    }
+    namespace OrganizationInsiderNoteAclControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationInsiderNoteAceDto;
+            }
+        }
+    }
+    namespace OrganizationInsiderNoteAclControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateOrganizationInsiderNoteAceDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationInsiderNoteAceDto;
+            }
+        }
+    }
+    namespace OrganizationNoteAclControllerCreate {
+        export type RequestBody = Components.Schemas.CreateOrganizationNoteAceDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationNoteAceDto;
+            }
+        }
+    }
+    namespace OrganizationNoteAclControllerFindAll {
+        namespace Parameters {
+            export type Limit = number;
+            export type NoteId = string;
+            export type OrganizationId = string;
+            export type Page = number;
+            export type SortBy = "id" | "organization" | "note" | "createdAt";
+            export type SortingOrder = "asc" | "desc";
+        }
+        export interface QueryParameters {
+            organizationId?: Parameters.OrganizationId;
+            noteId?: Parameters.NoteId;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.OrganizationNoteAceDto[];
+                };
+            }
+        }
+    }
+    namespace OrganizationNoteAclControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationNoteAceDto;
+            }
+        }
+    }
+    namespace OrganizationNoteAclControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationNoteAceDto;
+            }
+        }
+    }
+    namespace OrganizationNoteAclControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateOrganizationNoteAceDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationNoteAceDto;
+            }
+        }
+    }
+    namespace OrganizationPlayerAclControllerCreate {
+        export type RequestBody = Components.Schemas.CreateOrganizationPlayerAceDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationPlayerAceDto;
+            }
+        }
+    }
+    namespace OrganizationPlayerAclControllerFindAll {
+        namespace Parameters {
+            export type Limit = number;
+            export type OrganizationId = string;
+            export type Page = number;
+            export type PlayerId = string;
+            export type SortBy = "id" | "organization" | "player" | "createdAt";
+            export type SortingOrder = "asc" | "desc";
+        }
+        export interface QueryParameters {
+            organizationId?: Parameters.OrganizationId;
+            playerId?: Parameters.PlayerId;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.OrganizationPlayerAceDto[];
+                };
+            }
+        }
+    }
+    namespace OrganizationPlayerAclControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationPlayerAceDto;
+            }
+        }
+    }
+    namespace OrganizationPlayerAclControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationPlayerAceDto;
+            }
+        }
+    }
+    namespace OrganizationPlayerAclControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateOrganizationPlayerAceDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationPlayerAceDto;
+            }
+        }
+    }
+    namespace OrganizationReportAclControllerCreate {
+        export type RequestBody = Components.Schemas.CreateOrganizationReportAceDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationReportAceDto;
+            }
+        }
+    }
+    namespace OrganizationReportAclControllerFindAll {
+        namespace Parameters {
+            export type Limit = number;
+            export type OrganizationId = string;
+            export type Page = number;
+            export type ReportId = string;
+            export type SortBy = "id" | "organization" | "report" | "createdAt";
+            export type SortingOrder = "asc" | "desc";
+        }
+        export interface QueryParameters {
+            organizationId?: Parameters.OrganizationId;
+            reportId?: Parameters.ReportId;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.OrganizationReportAceDto[];
+                };
+            }
+        }
+    }
+    namespace OrganizationReportAclControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationReportAceDto;
+            }
+        }
+    }
+    namespace OrganizationReportAclControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationReportAceDto;
+            }
+        }
+    }
+    namespace OrganizationReportAclControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateOrganizationReportAceDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationReportAceDto;
+            }
+        }
+    }
+    namespace OrganizationSubscriptionsControllerCreate {
+        export type RequestBody = Components.Schemas.CreateOrganizationSubscriptionDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationSubscriptionDto;
+            }
+            export interface $201 {
+            }
+        }
+    }
+    namespace OrganizationSubscriptionsControllerFindAll {
+        namespace Parameters {
+            export type CompetitionGroupIds = string[];
+            export type CompetitionIds = string[];
+            export type Limit = number;
+            export type OrganizationId = string;
+            export type Page = number;
+            export type SortBy = "id" | "organization" | "startDate" | "endDate";
+            export type SortingOrder = "asc" | "desc";
+        }
+        export interface QueryParameters {
+            organizationId?: Parameters.OrganizationId;
+            competitionIds?: Parameters.CompetitionIds;
+            competitionGroupIds?: Parameters.CompetitionGroupIds;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.OrganizationSubscriptionDto[];
+                };
+            }
+        }
+    }
+    namespace OrganizationSubscriptionsControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationSubscriptionDto;
+            }
+        }
+    }
+    namespace OrganizationSubscriptionsControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationSubscriptionDto;
+            }
+        }
+    }
+    namespace OrganizationSubscriptionsControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateOrganizationSubscriptionDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationSubscriptionDto;
+            }
+        }
+    }
+    namespace OrganizationsControllerAddMember {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.ToggleMembershipDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationDto;
+            }
+        }
+    }
+    namespace OrganizationsControllerCreate {
+        export type RequestBody = Components.Schemas.CreateOrganizationDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationDto;
+            }
+        }
+    }
+    namespace OrganizationsControllerFindAll {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationDto;
+            }
+        }
+    }
+    namespace OrganizationsControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationDto;
+            }
+        }
+    }
+    namespace OrganizationsControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationDto;
+            }
+        }
+    }
+    namespace OrganizationsControllerRemoveMember {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.ToggleMembershipDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationDto;
+            }
+        }
+    }
+    namespace OrganizationsControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateOrganizationDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.OrganizationDto;
+            }
+        }
+    }
+    namespace PlayerPositionsControllerCreate {
+        export type RequestBody = Components.Schemas.CreatePlayerPositionDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.PlayerPositionDto;
+            }
+        }
+    }
+    namespace PlayerPositionsControllerFindAll {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.PlayerPositionDto[];
+            }
+        }
+    }
+    namespace PlayerPositionsControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.PlayerPositionDto;
+            }
+        }
+    }
+    namespace PlayerPositionsControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.PlayerPositionDto;
+            }
+        }
+    }
+    namespace PlayerPositionsControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdatePlayerPositionDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.PlayerPositionDto;
+            }
+        }
+    }
+    namespace PlayerStatsControllerCreate {
+        export type RequestBody = Components.Schemas.CreatePlayerStatsDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.PlayerStatsDto;
+            }
+        }
+    }
+    namespace PlayerStatsControllerFindAll {
+        namespace Parameters {
+            export type Limit = number;
+            export type MatchId = string;
+            export type Page = number;
+            export type PlayerId = string;
+            export type SortBy = "id" | "player" | "match" | "goals" | "assists" | "minutesPlayed" | "yellowCards" | "redCards";
+            export type SortingOrder = "asc" | "desc";
+            export type TeamId = string;
+        }
+        export interface QueryParameters {
+            playerId?: Parameters.PlayerId;
+            teamId?: Parameters.TeamId;
+            matchId?: Parameters.MatchId;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.PlayerStatsDto[];
+                };
+            }
+        }
+    }
+    namespace PlayerStatsControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.PlayerStatsDto;
+            }
+        }
+    }
+    namespace PlayerStatsControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.PlayerStatsDto;
+            }
+        }
+    }
+    namespace PlayerStatsControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdatePlayerStatsDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.PlayerStatsDto;
+            }
+        }
+    }
+    namespace PlayersControllerCreate {
+        export type RequestBody = Components.Schemas.CreatePlayerDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.PlayerDto;
+            }
+        }
+    }
+    namespace PlayersControllerFindAll {
+        namespace Parameters {
+            export type BornAfter = number;
+            export type BornBefore = number;
+            export type CompetitionGroupIds = string[];
+            export type CompetitionIds = string[];
+            export type CountryIds = string[];
+            export type Footed = "LEFT" | "RIGHT" | "BOTH";
+            export type IsLiked = boolean;
+            export type Limit = number;
+            export type Name = string;
+            export type Page = number;
+            export type PositionIds = string[];
+            export type SortBy = "id" | "firstName" | "lastName" | "yearOfBirth" | "height" | "weight" | "footed" | "country" | "primaryPosition" | "reportsCount" | "notesCount";
+            export type SortingOrder = "asc" | "desc";
+            export type TeamIds = string[];
+        }
+        export interface QueryParameters {
+            name?: Parameters.Name;
+            bornAfter?: Parameters.BornAfter;
+            bornBefore?: Parameters.BornBefore;
+            footed?: Parameters.Footed;
+            countryIds?: Parameters.CountryIds;
+            positionIds?: Parameters.PositionIds;
+            teamIds?: Parameters.TeamIds;
+            competitionIds?: Parameters.CompetitionIds;
+            competitionGroupIds?: Parameters.CompetitionGroupIds;
+            isLiked?: Parameters.IsLiked;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.PlayerDto[];
+                };
+            }
+        }
+    }
+    namespace PlayersControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.PlayerDto;
+            }
+        }
+    }
+    namespace PlayersControllerGetList {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.PlayerBasicDataDto;
+            }
+        }
+    }
+    namespace PlayersControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.PlayerDto;
+            }
+        }
+    }
+    namespace PlayersControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdatePlayerDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.PlayerDto;
+            }
+        }
+    }
+    namespace RegionsControllerCreate {
+        export type RequestBody = Components.Schemas.CreateRegionDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.RegionDto;
+            }
+        }
+    }
+    namespace RegionsControllerFindAll {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.RegionDto[];
+            }
+        }
+    }
+    namespace RegionsControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.RegionDto;
+            }
+        }
+    }
+    namespace RegionsControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.RegionDto;
+            }
+        }
+    }
+    namespace RegionsControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateRegionDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.RegionDto;
+            }
+        }
+    }
+    namespace ReportBackgroundImagesControllerCreate {
+        export type RequestBody = Components.Schemas.CreateReportBackgroundImageDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportBackgroundImageDto;
+            }
+        }
+    }
+    namespace ReportBackgroundImagesControllerFindAll {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportBackgroundImageDto;
+            }
+        }
+    }
+    namespace ReportBackgroundImagesControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportBackgroundImageDto;
+            }
+        }
+    }
+    namespace ReportBackgroundImagesControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportBackgroundImageDto;
+            }
+        }
+    }
+    namespace ReportBackgroundImagesControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateReportBackgroundImageDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportBackgroundImageDto;
+            }
+        }
+    }
+    namespace ReportSkillAssessmentCategoriesControllerCreate {
+        export type RequestBody = Components.Schemas.CreateReportSkillAssessmentCategoryDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportSkillAssessmentCategoryDto;
+            }
+        }
+    }
+    namespace ReportSkillAssessmentCategoriesControllerFindAll {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportSkillAssessmentCategoryDto;
+            }
+        }
+    }
+    namespace ReportSkillAssessmentCategoriesControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportSkillAssessmentCategoryDto;
+            }
+        }
+    }
+    namespace ReportSkillAssessmentCategoriesControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportSkillAssessmentCategoryDto;
+            }
+        }
+    }
+    namespace ReportSkillAssessmentCategoriesControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateReportSkillAssessmentCategoryDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportSkillAssessmentCategoryDto;
+            }
+        }
+    }
+    namespace ReportSkillAssessmentTemplatesControllerCreate {
+        export type RequestBody = Components.Schemas.CreateReportSkillAssessmentTemplateDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportSkillAssessmentTemplateDto;
+            }
+        }
+    }
+    namespace ReportSkillAssessmentTemplatesControllerFindAll {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportSkillAssessmentTemplateDto;
+            }
+        }
+    }
+    namespace ReportSkillAssessmentTemplatesControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportSkillAssessmentTemplateDto;
+            }
+        }
+    }
+    namespace ReportSkillAssessmentTemplatesControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportSkillAssessmentTemplateDto;
+            }
+        }
+    }
+    namespace ReportSkillAssessmentTemplatesControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateReportSkillAssessmentTemplateDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportSkillAssessmentTemplateDto;
+            }
+        }
+    }
+    namespace ReportSkillAssessmentsControllerFindAll {
+        namespace Parameters {
+            export type Limit = number;
+            export type MatchId = string;
+            export type Page = number;
+            export type PlayerId = string;
+            export type SortBy = "id" | "rating" | "player" | "match";
+            export type SortingOrder = "asc" | "desc";
+        }
+        export interface QueryParameters {
+            playerId?: Parameters.PlayerId;
+            matchId?: Parameters.MatchId;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.ReportSkillAssessmentDto[];
+                };
+            }
+        }
+    }
+    namespace ReportTemplatesControllerCreate {
+        export type RequestBody = Components.Schemas.CreateReportTemplateDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportTemplateDto;
+            }
+        }
+    }
+    namespace ReportTemplatesControllerFindAll {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportTemplateDto;
+            }
+        }
+    }
+    namespace ReportTemplatesControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportTemplateDto;
+            }
+        }
+    }
+    namespace ReportTemplatesControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportTemplateDto;
+            }
+        }
+    }
+    namespace ReportTemplatesControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateReportTemplateDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportTemplateDto;
+            }
+        }
+    }
+    namespace ReportsControllerCreate {
+        export type RequestBody = Components.Schemas.CreateReportDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportDto;
+            }
+        }
+    }
+    namespace ReportsControllerFindAll {
+        namespace Parameters {
+            export type CompetitionGroupIds = string[];
+            export type CompetitionIds = string[];
+            export type HasVideo = boolean;
+            export type IsLiked = boolean;
+            export type Limit = number;
+            export type MatchIds = string[];
+            export type Page = number;
+            export type PercentageRatingRangeEnd = number;
+            export type PercentageRatingRangeStart = number;
+            export type PlayerBornAfter = number;
+            export type PlayerBornBefore = number;
+            export type PlayerIds = string[];
+            export type PositionIds = string[];
+            export type SortBy = "id" | "player" | "positionPlayed" | "finalRating" | "percentageRating" | "videoUrl" | "author" | "createdAt" | "status";
+            export type SortingOrder = "asc" | "desc";
+            export type TeamIds = string[];
+        }
+        export interface QueryParameters {
+            playerIds?: Parameters.PlayerIds;
+            positionIds?: Parameters.PositionIds;
+            matchIds?: Parameters.MatchIds;
+            teamIds?: Parameters.TeamIds;
+            competitionIds?: Parameters.CompetitionIds;
+            competitionGroupIds?: Parameters.CompetitionGroupIds;
+            percentageRatingRangeStart?: Parameters.PercentageRatingRangeStart;
+            percentageRatingRangeEnd?: Parameters.PercentageRatingRangeEnd;
+            playerBornAfter?: Parameters.PlayerBornAfter;
+            playerBornBefore?: Parameters.PlayerBornBefore;
+            hasVideo?: Parameters.HasVideo;
+            isLiked?: Parameters.IsLiked;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.ReportPaginatedDataDto[];
+                };
+            }
+        }
+    }
+    namespace ReportsControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportDto;
+            }
+        }
+    }
+    namespace ReportsControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportDto;
+            }
+        }
+    }
+    namespace ReportsControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateReportDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.ReportDto;
+            }
+        }
+    }
+    namespace SeasonsControllerCreate {
+        export type RequestBody = Components.Schemas.CreateSeasonDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.SeasonDto;
+            }
+        }
+    }
+    namespace SeasonsControllerFindAll {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.SeasonDto;
+            }
+        }
+    }
+    namespace SeasonsControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.SeasonDto;
+            }
+        }
+    }
+    namespace SeasonsControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.SeasonDto;
+            }
+        }
+    }
+    namespace SeasonsControllerToggleIsActive {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.ToggleIsActiveDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.SeasonDto;
+            }
+        }
+    }
+    namespace SeasonsControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateSeasonDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.SeasonDto;
+            }
+        }
+    }
+    namespace TeamAffiliationsControllerCreate {
+        export type RequestBody = Components.Schemas.CreateTeamAffiliationDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.TeamAffiliationDto;
+            }
+        }
+    }
+    namespace TeamAffiliationsControllerFindAll {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.TeamAffiliationDto;
+            }
+        }
+    }
+    namespace TeamAffiliationsControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.TeamAffiliationDto;
+            }
+        }
+    }
+    namespace TeamAffiliationsControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.TeamAffiliationDto;
+            }
+        }
+    }
+    namespace TeamAffiliationsControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateTeamAffiliationDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.TeamAffiliationDto;
+            }
+        }
+    }
+    namespace TeamsControllerCreate {
+        export type RequestBody = Components.Schemas.CreateTeamDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.TeamDto;
+            }
+        }
+    }
+    namespace TeamsControllerFindAll {
+        namespace Parameters {
+            export type ClubId = string;
+            export type CompetitionGroupIds = string[];
+            export type CompetitionIds = string[];
+            export type CountryIds = string[];
+            export type IsLiked = boolean;
+            export type Limit = number;
+            export type Name = string;
+            export type Page = number;
+            export type RegionIds = string[];
+            export type SortBy = "id" | "name" | "clubId" | "countryId" | "regionId";
+            export type SortingOrder = "asc" | "desc";
+        }
+        export interface QueryParameters {
+            name?: Parameters.Name;
+            clubId?: Parameters.ClubId;
+            regionIds?: Parameters.RegionIds;
+            countryIds?: Parameters.CountryIds;
+            competitionIds?: Parameters.CompetitionIds;
+            competitionGroupIds?: Parameters.CompetitionGroupIds;
+            isLiked?: Parameters.IsLiked;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.TeamDto[];
+                };
+            }
+        }
+    }
+    namespace TeamsControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.TeamDto;
+            }
+        }
+    }
+    namespace TeamsControllerGetList {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.TeamBasicDataDto;
+            }
+        }
+    }
+    namespace TeamsControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.TeamDto;
+            }
+        }
+    }
+    namespace TeamsControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateTeamDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.TeamDto;
+            }
+        }
+    }
+    namespace UserFootballRolesControllerCreate {
+        export type RequestBody = Components.Schemas.CreateUserFootballRoleDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserFootballRoleDto;
+            }
+            export interface $201 {
+            }
+        }
+    }
+    namespace UserFootballRolesControllerFindAll {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserFootballRoleDto;
+            }
+        }
+    }
+    namespace UserFootballRolesControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserFootballRoleDto;
+            }
+        }
+    }
+    namespace UserFootballRolesControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserFootballRoleDto;
+            }
+        }
+    }
+    namespace UserFootballRolesControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateUserFootballRoleDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserFootballRoleDto;
+            }
+        }
+    }
+    namespace UserInsiderNoteAclControllerCreate {
+        export type RequestBody = Components.Schemas.CreateUserInsiderNoteAceDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserInsiderNoteAceDto;
+            }
+        }
+    }
+    namespace UserInsiderNoteAclControllerFindAll {
+        namespace Parameters {
+            export type InsiderNoteId = string;
+            export type Limit = number;
+            export type Page = number;
+            export type SortBy = "id" | "user" | "insiderNote" | "createdAt";
+            export type SortingOrder = "asc" | "desc";
+            export type UserId = string;
+        }
+        export interface QueryParameters {
+            userId?: Parameters.UserId;
+            insiderNoteId?: Parameters.InsiderNoteId;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.UserInsiderNoteAceDto[];
+                };
+            }
+        }
+    }
+    namespace UserInsiderNoteAclControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserInsiderNoteAceDto;
+            }
+        }
+    }
+    namespace UserInsiderNoteAclControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserInsiderNoteAceDto;
+            }
+        }
+    }
+    namespace UserInsiderNoteAclControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateUserInsiderNoteAceDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserInsiderNoteAceDto;
+            }
+        }
+    }
+    namespace UserNoteAclControllerCreate {
+        export type RequestBody = Components.Schemas.CreateUserNoteAceDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserNoteAceDto;
+            }
+        }
+    }
+    namespace UserNoteAclControllerFindAll {
+        namespace Parameters {
+            export type Limit = number;
+            export type NoteId = string;
+            export type Page = number;
+            export type SortBy = "id" | "user" | "note" | "createdAt";
+            export type SortingOrder = "asc" | "desc";
+            export type UserId = string;
+        }
+        export interface QueryParameters {
+            userId?: Parameters.UserId;
+            noteId?: Parameters.NoteId;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.UserNoteAceDto[];
+                };
+            }
+        }
+    }
+    namespace UserNoteAclControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserNoteAceDto;
+            }
+        }
+    }
+    namespace UserNoteAclControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserNoteAceDto;
+            }
+        }
+    }
+    namespace UserNoteAclControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateUserNoteAceDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserNoteAceDto;
+            }
+        }
+    }
+    namespace UserPlayerAclControllerCreate {
+        export type RequestBody = Components.Schemas.CreateUserPlayerAceDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserPlayerAceDto;
+            }
+        }
+    }
+    namespace UserPlayerAclControllerFindAll {
+        namespace Parameters {
+            export type Limit = number;
+            export type Page = number;
+            export type PlayerId = string;
+            export type SortBy = "id" | "user" | "player" | "createdAt";
+            export type SortingOrder = "asc" | "desc";
+            export type UserId = string;
+        }
+        export interface QueryParameters {
+            userId?: Parameters.UserId;
+            playerId?: Parameters.PlayerId;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.UserPlayerAceDto[];
+                };
+            }
+        }
+    }
+    namespace UserPlayerAclControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserPlayerAceDto;
+            }
+        }
+    }
+    namespace UserPlayerAclControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserPlayerAceDto;
+            }
+        }
+    }
+    namespace UserPlayerAclControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateUserPlayerAceDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserPlayerAceDto;
+            }
+        }
+    }
+    namespace UserReportAclControllerCreate {
+        export type RequestBody = Components.Schemas.CreateUserReportAceDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserReportAceDto;
+            }
+        }
+    }
+    namespace UserReportAclControllerFindAll {
+        namespace Parameters {
+            export type Limit = number;
+            export type Page = number;
+            export type ReportId = string;
+            export type SortBy = "id" | "user" | "report" | "createdAt";
+            export type SortingOrder = "asc" | "desc";
+            export type UserId = string;
+        }
+        export interface QueryParameters {
+            userId?: Parameters.UserId;
+            reportId?: Parameters.ReportId;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.UserReportAceDto[];
+                };
+            }
+        }
+    }
+    namespace UserReportAclControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserReportAceDto;
+            }
+        }
+    }
+    namespace UserReportAclControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserReportAceDto;
+            }
+        }
+    }
+    namespace UserReportAclControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateUserReportAceDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserReportAceDto;
+            }
+        }
+    }
+    namespace UserSubscriptionsControllerCreate {
+        export type RequestBody = Components.Schemas.CreateUserSubscriptionDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserSubscriptionDto;
+            }
+            export interface $201 {
+            }
+        }
+    }
+    namespace UserSubscriptionsControllerFindAll {
+        namespace Parameters {
+            export type CompetitionGroupIds = string[];
+            export type CompetitionIds = string[];
+            export type Limit = number;
+            export type Page = number;
+            export type SortBy = "id" | "user" | "startDate" | "endDate";
+            export type SortingOrder = "asc" | "desc";
+            export type UserId = string;
+        }
+        export interface QueryParameters {
+            userId?: Parameters.UserId;
+            competitionIds?: Parameters.CompetitionIds;
+            competitionGroupIds?: Parameters.CompetitionGroupIds;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.UserSubscriptionDto[];
+                };
+            }
+        }
+    }
+    namespace UserSubscriptionsControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserSubscriptionDto;
+            }
+        }
+    }
+    namespace UserSubscriptionsControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserSubscriptionDto;
+            }
+        }
+    }
+    namespace UserSubscriptionsControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdateUserSubscriptionDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserSubscriptionDto;
+            }
+        }
+    }
+    namespace UsersControllerChangeRole {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.ChangeRoleDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserDto;
+            }
+        }
+    }
+    namespace UsersControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserDto;
+            }
+        }
+    }
+    namespace UsersControllerGetList {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.UserBasicDataDto[];
+            }
+        }
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -752,6 +752,13 @@ acorn@^8.4.1, acorn@^8.7.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
   integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
 
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
+
 ajv@^6.10.0, ajv@^6.12.4, ajv@^6.12.6:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -981,6 +988,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+commander@^9.0.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.2.0.tgz#6e21014b2ed90d8b7c9647230d8b7a94a4a419a9"
+  integrity sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==
+
 compare-func@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/compare-func/-/compare-func-2.0.0.tgz#fb65e75edbddfd2e568554e8b5b05fff7a51fcb3"
@@ -1080,6 +1092,13 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-fetch@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -1104,6 +1123,13 @@ dargs@^7.0.0:
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-7.0.0.tgz#04015c41de0bcb69ec84050f3d9be0caf8d6d5cc"
   integrity sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==
 
+debug@4, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1117,13 +1143,6 @@ debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
-  dependencies:
-    ms "2.1.2"
 
 decamelize-keys@^1.1.0:
   version "1.1.0"
@@ -1191,6 +1210,20 @@ dot-prop@^5.1.0:
   integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
   dependencies:
     is-obj "^2.0.0"
+
+dtsgenerator@^3.15.1:
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/dtsgenerator/-/dtsgenerator-3.15.1.tgz#03d43c81bb858cb5e0f80307ff459739229c0790"
+  integrity sha512-ny3Fl5uF8ePCUPSHuMU6OJQ31mbUJ5cH0rxclJsMot+BSpgykz3Rz3Gjy9fOjKAXJCPNEyukvMYhSkChNgAS4w==
+  dependencies:
+    commander "^9.0.0"
+    cross-fetch "^3.1.5"
+    debug "^4.3.3"
+    glob "^7.2.0"
+    https-proxy-agent "^5.0.0"
+    js-yaml "^4.1.0"
+    tslib "^2.3.1"
+    typescript "^4.6.2"
 
 duplexer2@^0.1.2:
   version "0.1.4"
@@ -1862,6 +1895,14 @@ html-tokenize@^2.0.0:
     readable-stream "~1.0.27-1"
     through2 "~0.4.1"
 
+https-proxy-agent@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
@@ -2336,6 +2377,13 @@ next@12.1.6:
     "@next/swc-win32-arm64-msvc" "12.1.6"
     "@next/swc-win32-ia32-msvc" "12.1.6"
     "@next/swc-win32-x64-msvc" "12.1.6"
+
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -3056,6 +3104,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
@@ -3095,6 +3148,11 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.3.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
@@ -3129,7 +3187,7 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@4.6.4, typescript@^4.4.3:
+typescript@4.6.4, typescript@^4.4.3, typescript@^4.6.2:
   version "4.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
@@ -3178,6 +3236,19 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### Task Description

- add `generate-types` script
- generate types based on backend API Swagger documentation

### Additional Notes (optional)

<!-- Provide any additional notes: related PRs, screenshots, et al.). -->
